### PR TITLE
カスタムdirective

### DIFF
--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -1,3 +1,3 @@
 <template>
-  <p>ホーム</p>
+  <p v-border>ホーム</p>
 </template>

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -1,3 +1,22 @@
 <template>
-  <p v-border>ホーム</p>
+  <p v-border:doted.round.shodow="'5px'">ホーム</p>
 </template>
+
+<script>
+export default {
+  // カスタムディレクティブのローカル登録
+  directives: {
+    border: function(el, binding) {
+      el.style.border = "solid red 2px";
+      el.style.borderWidth = binding.value;
+      el.style.borderStyle = binding.arg;
+      if (binding.modifiers) {
+        el.style.borderRadius = "1rem";
+      }
+      if (binding.modifiers) {
+        el.style.boxShodow = "0 3px 5px rgba(0, 0, 0, 0.5)";
+      }
+    }
+  }
+};
+</script>

--- a/src/main.js
+++ b/src/main.js
@@ -6,24 +6,22 @@ import LikeNumber from "./components/LikeNumber"
 Vue.config.productionTip = false
 //コンポーネントのグローバル登録
 Vue.component('LikeNumber', LikeNumber);
+
 //カスタムディレクティブのグローバル登録
-Vue.directive("border", {
-  bind(el, binding, vnode) {
+// Vue.directive("border", {
+  // bind(el, binding, vnode) {
     // ディレクティブが初めて対象の要素に紐づいたとき
-  },
-  inserted() {
-    // 親NODEに挿入された時
-  },
-  update() {
+  // },
+  // update(el, binding, vnode) {
     // コンポーネントが更新される度、子コンポーネントが更新される前
-  },
-  componentUpdated() {
-    // コンポーネントが更新される度、子コンポーンとが更新された後
-  },
-  unbind() {
-    // ディレクティブが紐付いている要素から取り除かれた時
-  }, 
-});
+  // },
+// });
+  
+// bindとupdateは頻出しやすいので省略記法が用意されている
+// Vue.directive("border", function(el, binding) {
+//   el.style.border = "solid black 2px";
+//   el.style.borderWidth = binding.value;
+// });
 
 new Vue({
   render: h => h(App),

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,25 @@ import LikeNumber from "./components/LikeNumber"
 
 Vue.config.productionTip = false
 //コンポーネントのグローバル登録
-Vue.component('LikeNumber', LikeNumber)
+Vue.component('LikeNumber', LikeNumber);
+//カスタムディレクティブのグローバル登録
+Vue.directive("border", {
+  bind(el, binding, vnode) {
+    // ディレクティブが初めて対象の要素に紐づいたとき
+  },
+  inserted() {
+    // 親NODEに挿入された時
+  },
+  update() {
+    // コンポーネントが更新される度、子コンポーネントが更新される前
+  },
+  componentUpdated() {
+    // コンポーネントが更新される度、子コンポーンとが更新された後
+  },
+  unbind() {
+    // ディレクティブが紐付いている要素から取り除かれた時
+  }, 
+});
 
 new Vue({
   render: h => h(App),


### PR DESCRIPTION
# directiveを自作することで描画を自由に
- カスタムするさいはコンポーネントと同じくグローバルかローカルの登録ができる
- ５つのライフサイクルフックを使って発火させるが基本はbindとdirectiveUpdatedの２つ
  - この２つについては省略記法が用意されていて→関数で書けるfunction( 引数 ){  }
- 引数にはel、binding、vnodeなどがある
  - elは挿入されるセレクタのこと
  - bindingはカスタムディレクティブにデータを渡す