### PR TITLE
Filter mixin

### DIFF
--- a/src/components/Count.vue
+++ b/src/components/Count.vue
@@ -1,0 +1,25 @@
+<template>
+  <div>
+    <h2>{{ title | upperCase }}</h2>
+    <p>{{ subTitle | upperCase }}</p>
+    <h2>{{ title | lowerCase }}</h2>
+    <p>{{ subTitle | lowerCase }}</p>
+  </div>
+</template>
+
+<script>
+export default {
+  data: function() {
+    return {
+      title: "Welcome to Tokyo",
+      subTitle: "Tokyo is a great city"
+    }
+  },
+  //フィルターのローカル登録
+  filters: {
+    lowerCase: function(value) {
+      return value.toLowerCase();
+    }
+  }
+};
+</script>

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -1,9 +1,22 @@
 <template>
-  <p v-border:doted.round.shodow="'5px'">ホーム</p>
+  <div>
+    <p v-border:doted.round.shodow="'5px'">ホーム</p>
+    <h2>{{ title | upperCase }}</h2>
+    <p>{{ subTitle | upperCase }}</p>
+    <h2>{{ title | lowerCase }}</h2>
+    <p>{{ subTitle | lowerCase }}</p>
+  </div>
 </template>
 
 <script>
 export default {
+  data: function() {
+    return {
+      title: "Welcome to Tokyo",
+      subTitle: "Tokyo is a great city"
+    }
+  },
+
   // カスタムディレクティブのローカル登録
   directives: {
     border: function(el, binding) {
@@ -16,6 +29,12 @@ export default {
       if (binding.modifiers) {
         el.style.boxShodow = "0 3px 5px rgba(0, 0, 0, 0.5)";
       }
+    }
+  },
+  //フィルターのローカル登録
+  filters: {
+    lowerCase: function(value) {
+      return value.toLowerCase();
     }
   }
 };

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -3,8 +3,6 @@
     <p v-border:doted.round.shodow="'5px'">ホーム</p>
     <h2>{{ title | upperCase }}</h2>
     <p>{{ subTitle | upperCase }}</p>
-    <h2>{{ title | lowerCase }}</h2>
-    <p>{{ subTitle | lowerCase }}</p>
   </div>
 </template>
 

--- a/src/main.js
+++ b/src/main.js
@@ -23,6 +23,11 @@ Vue.component('LikeNumber', LikeNumber);
 //   el.style.borderWidth = binding.value;
 // });
 
+//フィルターのグローバル登録
+Vue.filter("upperCase", function(value) {
+  return value.toUpperCase();
+});
+
 new Vue({
   render: h => h(App),
 }).$mount('#app')


### PR DESCRIPTION
# filterとmixinについて
- filterとはフォーマットを揃える際に使用。
  - computedでも可能だが動揺箇所が複数あると都度記述が必要になり冗長になる。
  - "{{ | }}"パイプでマスタッシュ内で記述。
  - 毎度のごとく、ローカルとグローバル登録がある。
- mixinは同じ構文を別のjsファイルに移して、そこから呼び出す
  - 使うイメージはSCSSと同じ。
  - 優先度はコンポーネント、ライフサイクルフックに関してはその限りでは無い。
  - こちらもローカルとグローバルがあるがグローバルで登録すると全てのコンポーネントに反映されることになる。使われることはまず無いと覚えとく。